### PR TITLE
Add sanitizeHTML converter and tests

### DIFF
--- a/src/types/string/converters/sanitizeHtmlConvertor.js
+++ b/src/types/string/converters/sanitizeHtmlConvertor.js
@@ -1,0 +1,29 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.SanitizeHtmlConvertor = void 0;
+const stringSchema_1 = require("../stringSchema");
+const registerConverter_1 = require("../../../schema/registerConverter");
+class SanitizeHtmlConvertor {
+    convert(params) {
+        let value = params.value;
+        const htmlTagPattern = /<([^>]+)>/gm;
+        const replaceMap = {
+            '<': '&lt;',
+            '>': '&gt;'
+        };
+        let isHtml = htmlTagPattern.test(value);
+        if (isHtml) {
+            value = value.replace(/[<>]/g, (m) => {
+                return replaceMap[m];
+            });
+        }
+        return value;
+    }
+}
+exports.SanitizeHtmlConvertor = SanitizeHtmlConvertor;
+registerConverter_1.registerConverter.extend({
+    base: stringSchema_1.StringSchema,
+    name: "sanitizeHTML",
+    converter: SanitizeHtmlConvertor
+});
+//# sourceMappingURL=sanitizeHtmlConvertor.js.map

--- a/src/types/string/converters/sanitizeHtmlConvertor.ts
+++ b/src/types/string/converters/sanitizeHtmlConvertor.ts
@@ -1,0 +1,32 @@
+import {StringSchema} from "../stringSchema";
+import {IConverter} from "../../../interfaces/IConverter";
+import {ValidationParams} from "../../../interfaces/IConstraint";
+import {registerConverter} from "../../../schema/registerConverter";
+
+
+export class SanitizeHtmlConvertor implements IConverter {
+    public convert(params: ValidationParams): string {
+        let value: string = params.value;
+        const htmlTagPattern = /<([^>]+)>/gm;
+        const replaceMap = {
+            '<': '&lt;',
+            '>': '&gt;'
+        };
+        let isHtml = htmlTagPattern.test(value);
+        if (isHtml) {
+            value = value.replace(/[<>]/g, (m) => {
+                return replaceMap[m];
+            });
+        }
+
+        return value;
+    }
+
+}
+
+registerConverter.extend({
+    base: StringSchema,
+    name: "sanitizeHTML",
+    converter: SanitizeHtmlConvertor
+});
+

--- a/src/types/string/stringSchema.ts
+++ b/src/types/string/stringSchema.ts
@@ -57,6 +57,5 @@ export interface StringSchema {
     alpha(options?: IConstraintOptions): this;
     alphanum(options?: IConstraintOptions): this;
     mongoSanitize(params?: {}, options?: IConstraintOptions): this;
-
-
+    sanitizeHTML(options?: IConverterOptions): this;
 }

--- a/test/unit.js
+++ b/test/unit.js
@@ -1170,6 +1170,20 @@ describe("validator", function () {
             result.errors.length.should.be.eq(1);
             result.errors[0].message.should.be.eq("test.a[0].a not a number");
         });
+        it.only('should validate sanitizeHtml convertor', async () => {
+            let validator = await index_1.validation();
+            let schema = index_1.string().sanitizeHTML();
+            let result = await validator.validate(schema, "<script>console.log('Hello World')</script>");
+            result.errors.length.should.be.eq(0);
+            result.value.should.be.eq("&lt;script&gt;console.log('Hello World')&lt;/script&gt;");
+        });
+        it.only('should not sanitizeHtml in case of formula', async () => {
+            let validator = await index_1.validation();
+            let schema = index_1.string().sanitizeHTML();
+            let result = await validator.validate(schema, "25 > 10");
+            result.errors.length.should.be.eq(0);
+            result.value.should.be.eq("25 > 10");
+        });
     });
 });
 //# sourceMappingURL=unit.js.map

--- a/test/unit.js
+++ b/test/unit.js
@@ -1170,14 +1170,14 @@ describe("validator", function () {
             result.errors.length.should.be.eq(1);
             result.errors[0].message.should.be.eq("test.a[0].a not a number");
         });
-        it.only('should validate sanitizeHtml convertor', async () => {
+        it('should validate sanitizeHtml convertor', async () => {
             let validator = await index_1.validation();
             let schema = index_1.string().sanitizeHTML();
             let result = await validator.validate(schema, "<script>console.log('Hello World')</script>");
             result.errors.length.should.be.eq(0);
             result.value.should.be.eq("&lt;script&gt;console.log('Hello World')&lt;/script&gt;");
         });
-        it.only('should not sanitizeHtml in case of formula', async () => {
+        it('should not sanitizeHtml in case of formula', async () => {
             let validator = await index_1.validation();
             let schema = index_1.string().sanitizeHTML();
             let result = await validator.validate(schema, "25 > 10");

--- a/test/unit.ts
+++ b/test/unit.ts
@@ -1897,6 +1897,31 @@ describe("validator", function () {
             result.errors.length.should.be.eq(1);
             result.errors[0].message.should.be.eq("test.a[0].a not a number")
         })
+
+
+        it.only('should validate sanitizeHtml convertor', async () => {
+            let validator = await validation();
+
+            let schema = string().sanitizeHTML();
+
+            let result = await validator.validate(schema, "<script>console.log('Hello World')</script>");
+
+            result.errors.length.should.be.eq(0);
+            result.value.should.be.eq("&lt;script&gt;console.log('Hello World')&lt;/script&gt;");
+        });
+
+        it.only('should not sanitizeHtml in case of formula', async () => {
+            let validator = await validation();
+
+            let schema = string().sanitizeHTML();
+
+            let result = await validator.validate(schema, "25 > 10");
+
+            result.errors.length.should.be.eq(0);
+            result.value.should.be.eq("25 > 10");
+        });
+
+
     })
 
 

--- a/test/unit.ts
+++ b/test/unit.ts
@@ -1899,7 +1899,7 @@ describe("validator", function () {
         })
 
 
-        it.only('should validate sanitizeHtml convertor', async () => {
+        it('should validate sanitizeHtml convertor', async () => {
             let validator = await validation();
 
             let schema = string().sanitizeHTML();
@@ -1910,7 +1910,7 @@ describe("validator", function () {
             result.value.should.be.eq("&lt;script&gt;console.log('Hello World')&lt;/script&gt;");
         });
 
-        it.only('should not sanitizeHtml in case of formula', async () => {
+        it('should not sanitizeHtml in case of formula', async () => {
             let validator = await validation();
 
             let schema = string().sanitizeHTML();


### PR DESCRIPTION
Implemented a new sanitizeHTML converter to the stringSchema. This converter removes potentially harmful HTML from input strings, reducing the risk of injection attacks. Also added corresponding tests to ensure the converter is properly sanitizing strings and not altering safe content.